### PR TITLE
Allow specification of "Resource" which is needed for AzureAD.

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -41,6 +41,7 @@ var Provider = exports.Provider = function () {
       var _config = this.config;
       var id = _config.id;
       var redirect_uri = _config.redirect_uri;
+      var resource = _ref.resource;
 
       var params = {
         client_id: id,
@@ -54,6 +55,9 @@ var Provider = exports.Provider = function () {
       }
       if (state) {
         params.state = state;
+      }
+      if(resource){
+        params.resource = resource;
       }
       if (!params.client_id || !params.redirect_uri) {
         callback('Invalid sign in params. ' + params.client_id + ' ' + params.redirect_uri);


### PR DESCRIPTION
Adds the capability to specify a resource, which is apparently needed by AzureAD or it will throw a 

{"error":"invalid_resource","error_description":"AADSTS50001: Resource identifier is not provided.\r\nTrace ID: 2b368764-3ad0-4555-b830-a42b08acdb77\r\nCorrelation ID: 9d5ac703-d29e-4a14-a768-12a1c5d1f96c\r\nTimestamp: 2016-12-14 21:26:09Z","error_codes":[50001],"timestamp":"2016-12-14 21:26:09Z","trace_id":"2b368764-3ad0-4555-b830-a42b08acdb77","correlation_id":"9d5ac703-d29e-4a14-a768-12a1c5d1f96c"}