### PR TITLE
Updates to support AzureAD login.

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -31,53 +31,52 @@ var Provider = exports.Provider = function () {
     this.config = config;
   }
 
+  /**
+   * SignIn - Performs the sign-in operation
+   * @param input_params - Object with parameters to pass to the authorize request client_id, redirect_uri and signin_uri are required keys.
+   * @param callback - Callback Function
+   */
+
+
   _createClass(Provider, [{
     key: 'signin',
-    value: function signin(_ref, callback) {
-      var signin_uri = _ref.signin_uri;
-      var scope = _ref.scope;
-      var state = _ref.state;
-      var response_type = _ref.response_type;
-      var _config = this.config;
-      var id = _config.id;
-      var redirect_uri = _config.redirect_uri;
-
-      var params = {
-        client_id: id,
-        redirect_uri: redirect_uri
+    value: function signin(input_params, callback) {
+      var params = { //Add Static Components
+        client_id: encodeURIComponent(this.config.id),
+        redirect_uri: encodeURIComponent(this.config.redirect_uri)
       };
-      if (response_type) {
-        params.response_type = response_type;
+
+      //Cycles through all input_params, ands adds to params with proper encoding
+      for (var key in input_params) {
+        //Pull all items out of ref & properly encode them
+        if (!input_params.hasOwnProperty(key)) continue; // skip loop if from prototype
+        params[key] = encodeURIComponent(input_params[key]);
       }
-      if (scope) {
-        params.scope = scope;
-      }
-      if (state) {
-        params.state = state;
-      }
+      delete params['signin_uri']; //Remove since for URL, not for param
+
       if (!params.client_id || !params.redirect_uri) {
         callback('Invalid sign in params. ' + params.client_id + ' ' + params.redirect_uri);
       } else {
-        var url = _utils.Utils.urlBuilder(signin_uri, params);
+        var url = _utils.Utils.urlBuilder(input_params.signin_uri, params);
         callback(null, { url: url });
       }
     }
   }, {
     key: 'callback',
-    value: function callback(_ref2, _ref3, additionalParams, cb) {
-      var code = _ref2.code;
-      var state = _ref2.state;
-      var authorization_uri = _ref3.authorization_uri;
-      var profile_uri = _ref3.profile_uri;
-      var profileMap = _ref3.profileMap;
-      var authorizationMethod = _ref3.authorizationMethod;
-      var authorization = additionalParams.authorization;
-      var profile = additionalParams.profile;
-      var _config2 = this.config;
-      var id = _config2.id;
-      var redirect_uri = _config2.redirect_uri;
-      var secret = _config2.secret;
-      var provider = _config2.provider;
+    value: function callback(_ref, _ref2, additionalParams, cb) {
+      var code = _ref.code,
+          state = _ref.state;
+      var authorization_uri = _ref2.authorization_uri,
+          profile_uri = _ref2.profile_uri,
+          profileMap = _ref2.profileMap,
+          authorizationMethod = _ref2.authorizationMethod;
+      var authorization = additionalParams.authorization,
+          profile = additionalParams.profile;
+      var _config = this.config,
+          id = _config.id,
+          redirect_uri = _config.redirect_uri,
+          secret = _config.secret,
+          provider = _config.provider;
 
 
       var attemptAuthorize = function attemptAuthorize() {
@@ -114,9 +113,8 @@ var Provider = exports.Provider = function () {
             reject(new Error('No access data'));
           }
 
-          var _JSON$parse = JSON.parse(accessData);
-
-          var access_token = _JSON$parse.access_token;
+          var _JSON$parse = JSON.parse(accessData),
+              access_token = _JSON$parse.access_token;
 
           var url = _utils.Utils.urlBuilder(profile_uri, Object.assign({ access_token: access_token }, profile));
           _request2.default.get(url, function (error, httpResponse, profileData) {
@@ -131,7 +129,7 @@ var Provider = exports.Provider = function () {
               var mappedProfile = profileMap ? profileMap(profileJson) : profileJson;
               resolve(mappedProfile);
             }
-          });
+          }).auth(null, null, true, access_token); //Add Bearer Token to Request
         });
       };
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -10,25 +10,28 @@ export class Provider {
     this.config = config;
   }
 
-  signin({ signin_uri, scope, state, response_type }, callback) {
-    const { id, redirect_uri } = this.config;
-    const params = {
-      client_id: id,
-      redirect_uri
+    /**
+     * SignIn - Performs the sign-in operation
+     * @param input_params - Object with parameters to pass to the authorize request client_id, redirect_uri and signin_uri are required keys.
+     * @param callback - Callback Function
+     */
+  signin(input_params, callback) {
+    const params = { //Add Static Components
+        client_id: encodeURIComponent(this.config.id),
+        redirect_uri: encodeURIComponent(this.config.redirect_uri)
     };
-    if (response_type) {
-      params.response_type = response_type;
+
+    //Cycles through all input_params, ands adds to params with proper encoding
+    for (var key in input_params) { //Pull all items out of ref & properly encode them
+      if (!input_params.hasOwnProperty(key)) continue;// skip loop if from prototype
+      params[key] = encodeURIComponent(input_params[key]);
     }
-    if (scope) {
-      params.scope = scope;
-    }
-    if (state) {
-      params.state = state;
-    }
+    delete params['signin_uri']; //Remove since for URL, not for param
+
     if (!params.client_id || !params.redirect_uri) {
       callback(`Invalid sign in params. ${params.client_id} ${params.redirect_uri}`);
     } else {
-      const url = Utils.urlBuilder(signin_uri, params);
+      const url = Utils.urlBuilder(input_params.signin_uri, params);
       callback(null, { url });
     }
   }
@@ -86,7 +89,7 @@ export class Provider {
           const mappedProfile = profileMap ? profileMap(profileJson) : profileJson;
           resolve(mappedProfile);
         }
-      });
+      }).auth(null, null, true, access_token);//Add Bearer Token to Request
     });
 
     attemptAuthorize()


### PR DESCRIPTION
The profile request for AzureAD requires an Auth Bearer header rather than an access_token in the URL. Since adding an extra header shouldn't ever hurt anything, updated the get call for the profile to include the access_token value in an Auth Bearer header in addition to including it on the URL.

I also updated the logic for the passing of parameters for the signin URL so that you can pass an arbitrary number of parameters over to meet the needs of any given provider. I thought this was a little more robust than just adding the "Resource" parameter by itself.

I also found the ability to add any parameter I wished to be very useful when trouble-shooting to try and figure out why my login was not behaving the same as Passport, since this would allow me to add/remove parameters from the original call.

